### PR TITLE
Separate emails for each report type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,20 @@ pip install git+https://github.com/dhs-ncats/cyhy-mailer.git
 ```bash
 Usage:
   cyhy-mailer [options]
-  cyhy-mailer (--cyhy-report-dir=DIRECTORY) (--financial-year=YEAR) (--fy-quarter=QUARTER) [--tmail-report-dir=DIRECTORY] [--https-report-dir=DIRECTORY] [--mail-server=SERVER] [--mail-port=PORT] [--db-creds-file=FILENAME] [--debug]
+  cyhy-mailer [--cyhy-report-dir=DIRECTORY] [--tmail-report-dir=DIRECTORY] [--https-report-dir=DIRECTORY] [--mail-server=SERVER] [--mail-port=PORT] [--db-creds-file=FILENAME] [--debug]
   cyhy-mailer (-h | --help)
 
 Options:
   -h --help                    Show this message.
   --cyhy-report-dir=DIRECTORY  The directory where the CYHY PDF reports are
-                               located.
-  -y --financial-year=YEAR     The two-digit financial year to which the
-                               reports being mailed out correspond.
-  -q --fy-quarter=QUARTER      The quarter of the financial year to which the
-                               reports being mailed out correspond.  Expected
-                               values are 1, 2, 3, or 4.
+                               located.  If not specified then no CYHY reports
+                               will be sent.
   --tmail-report-dir=DIRECTORY The directory where the trustymail PDF reports
-                               are located.  If it exists, the corresponding
-                               trustymail report will also be attached to an
-                               agency's CYHY email.
+                               are located.  If not specified then no trustymail
+                               reports will be sent.
   --https-report-dir=DIRECTORY The directory where the https-scan PDF reports
-                               are located.  If it exists, the corresponding
-                               https-scan report will also be attached to an
-                               agency's CYHY email.
+                               are located.  If not specified then no https-scan
+                               reports will be sent.
   -m --mail-server=SERVER      The hostname or IP address of the mail server
                                that should send the messages.
                                [default: smtp01.ncats.dhs.gov]

--- a/cyhy/mailer/HttpsMessage.py
+++ b/cyhy/mailer/HttpsMessage.py
@@ -1,0 +1,137 @@
+import pystache
+
+from cyhy.mailer.Message import Message
+from cyhy.mailer.ReportMessage import ReportMessage
+
+
+class HttpsMessage(ReportMessage):
+    """A class representing an email message with an HTTPS report
+    PDF attachment.
+
+    Static attributes
+    -----------------
+    Subject : str
+        The mustache template to use when constructing the message
+        subject.
+
+    TextBody : str
+        The mustache template to use when constructing the plain text
+        message body.
+
+    HtmlBody : str
+        The mustache template to use when constructing the HTML
+        message body.
+    """
+
+    Subject = '{{acronym}} - HTTPS Report - {{report_date}} Results'
+
+    TextBody = '''Greetings {{acronym}},
+
+Attached is your latest HTTPS Report.
+
+This report is intended to assist your agency in complying with OMB M-15-13 and DHS Binding Operational Directive 18-01. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)
+
+This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's Digital Analytics Program, Censys.io, and data from the End of Term Web Archive. The data in this report comes from a scan that took place on {{report_date}}.
+
+The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. For domains where "Live" == "True", when "Domain Supports HTTPS", "Domain Enforces HTTPS", and "Domain Uses Strong HSTS" are all "True", OR where "HSTS Base Domain Preloaded" is "True", that domain is M-15-13 compliant. Domains where "Live" == "False" are not web-responsive and do not fall under M-15-13's scope.
+
+We welcome your feedback and questions.
+
+Cheers,<br>
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity and Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+03/28/2017
+* Fixed: Compliance scores in the "Executive Summary" now account for preloaded domains. Preloading is OMB's preferred method for HSTS compliance.
+
+02/15/2017
+* Fixed an issue where some hostnames would appear twice in pshtt-results.csv
+* Fixed: A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly
+* Known issue: Compliance scores in the "Executive Summary" section are not yet accounting for preloaded domains
+
+01/25/2017
+* Fixed: A flaw in the report logic would sometimes cause the "Results" section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were "HSTS Preload Ready" or "HSTS Preload Pending" as preloaded (a checkmark).
+* Added: The report will now represent domains with "bad chain" errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 not requiring the use of a particular certificate authority
+--------------------
+'''
+
+    HtmlBody = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings {{acronym}},</p>
+<p>Attached is your latest HTTPS Report.</p>
+<p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and DHS <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)</p>
+<p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on {{report_date}}.</b></p>
+<p>The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. <i>For domains where &ldquo;Live&rdquo; == &ldquo;True&rdquo;</i>, when &ldquo;Domain Supports HTTPS&rdquo;, &ldquo;Domain Enforces HTTPS&rdquo;, and &ldquo;Domain Uses Strong HSTS&rdquo; are all &ldquo;True&rdquo;, OR where &ldquo;HSTS Base Domain Preloaded&rdquo; is &ldquo;True&rdquo;, that domain is M-15-13 compliant. Domains where &ldquo;Live&rdquo; == &ldquo;False&rdquo; are not web-responsive and do not fall under M-15-13's scope.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity and Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a>
+</p>
+</div>
+</p><br>
+<p>----changelog----</p>
+<p><i>03/28/2017</i></p>
+<p><b>* Fixed:</b> Compliance scores in the &ldquo;Executive Summary&rdquo; now account for preloaded domains. Preloading is OMB's <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">preferred method</a> for HSTS compliance.</p></p>
+<p><i>02/15/2017</i></p>
+<p><b>* Fixed</b> an issue where some hostnames would appear twice in<b> pshtt-results.csv <br>
+* Fixed: </b>A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly<br>
+<b>* Known issue</b>: Compliance scores in the &ldquo;Executive Summary&rdquo; section are not yet accounting for preloaded domains</p>
+<p><i>01/25/2017</i></p>
+<p><b>* Fixed</b>: A flaw in the report logic would sometimes cause the &ldquo;Results&rdquo; section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were &ldquo;HSTS Preload Ready&rdquo; or &ldquo;HSTS Preload Pending&rdquo; as preloaded (a checkmark).<br>
+<b>* Added</b>: The report will now represent domains with &ldquo;bad chain&rdquo; errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 <a href="https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f">not requiring the use of a particular certificate authority</a>.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+
+    def __init__(self, to_addrs, pdf_filename, agency_acronym, report_date, from_addr=Message.DefaultFrom, cc_addrs=Message.DefaultCc):
+        """Construct an instance.
+
+        Parameters
+        ----------
+        to_addrs : array of str
+            An array of string objects, each of which is an email
+            address to which this message should be sent.
+
+        pdf_filename : str
+            The filename of the PDF file that is the Trustworthy Email
+            report corresponding to this message.
+
+        agency_acronym : str
+            The acronym used by the agency corresponding to the
+            Trustworthy Email report attachment.
+
+        report_date : str
+            The date corresponding to the Trustworthy Email report
+            attachment.  We have been using dates of the form December
+            12, 2017.
+
+        from_addr : str
+            The email address from which this message is to be sent.
+
+        cc_addrs : array of str
+            An array of string objects, each of which is a CC email
+            address to which this message should be sent.
+        """
+        # This is the data mustache will use to render the templates
+        mustache_data = {
+            'acronym': agency_acronym,
+            'report_date': report_date
+        }
+
+        # Render the templates
+        subject = pystache.render(HttpsMessage.Subject, mustache_data)
+        text_body = pystache.render(HttpsMessage.TextBody, mustache_data)
+        html_body = pystache.render(HttpsMessage.HtmlBody, mustache_data)
+
+        ReportMessage.__init__(self, to_addrs, subject, text_body, html_body, pdf_filename, from_addr, cc_addrs)

--- a/cyhy/mailer/Message.py
+++ b/cyhy/mailer/Message.py
@@ -1,0 +1,118 @@
+from email import encoders
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import logging
+import os.path
+
+
+class Message(MIMEMultipart):
+    """A class representing an email message sent from the NCATS inbox.
+
+    Static attributes
+    -----------------
+    DefaultFrom : str
+        The default value for the address from which the message
+        should be sent.
+
+    DefaultCc : str
+        The default value for the CC addresses to which the message
+        should be sent.
+    """
+
+    DefaultFrom = 'ncats@hq.dhs.gov'
+
+    DefaultCc = ['ncats@hq.dhs.gov']
+
+    def __init__(self, to_addrs, subject=None, text_body=None, html_body=None, from_addr=DefaultFrom, cc_addrs=DefaultCc):
+        """Construct an instance.
+
+        Parameters
+        ----------
+        to_addrs : array of str
+            An array of string objects, each of which is an email
+            address to which this message should be sent.
+
+        subject : str
+            The subject of this email message.
+
+        text_body : str
+            The plain-text version of the email body.
+
+        html_body : str
+            The HTML version of the email body.
+
+        from_addr : str
+            The email address from which this message is to be sent.
+
+        cc_addrs : array of str
+            An array of string objects, each of which is a CC email
+            address to which this message should be sent.
+        """
+        MIMEMultipart.__init__(self)
+
+        self['From'] = from_addr
+        logging.debug('Message to be sent from: %s', self['From'])
+
+        self['To'] = ','.join(to_addrs)
+        logging.debug('Message to be sent to: %s', self['To'])
+
+        if cc_addrs:
+            self['CC'] = ','.join(cc_addrs)
+            logging.debug('Message to be sent as CC to: %s', self['CC'])
+
+        if subject:
+            self['Subject'] = subject
+            logging.debug('Message subject: %s', subject)
+
+        #
+        # The order is important here.  This order makes the HTML
+        # version the default version that is displayed, as long as
+        # the client supports it.
+        #
+        if html_body:
+            self.attach_html_body(html_body)
+
+        if text_body:
+            self.attach_text_body(text_body)
+
+    def attach_text_body(self, text):
+        """Attach a plain text body to this message.
+
+        Parameters
+        ----------
+        text : str
+            The plain text to attach.
+        """
+        self.attach(MIMEText(text, 'plain'))
+        logging.debug('Message plain-text body: %s', text)
+
+    def attach_html_body(self, html):
+        """Attach an HTML text body to this message.
+
+        Parameters
+        ----------
+        html : str
+            The HTML text to attach.
+        """
+        part = MIMEText(html, 'html')
+        part.add_header('Content-Disposition', 'inline')
+        self.attach(part)
+        logging.debug('Message HTML body: %s', html)
+
+    def attach_pdf(self, pdf_filename):
+        """Attach a PDF file to this message.
+
+        Parameters
+        ----------
+        pdf_filename : str
+            The filename of the PDF file to attach.
+        """
+        attachment = open(pdf_filename, 'rb')
+        part = MIMEApplication(attachment.read(), 'pdf')
+        encoders.encode_base64(part)
+        # See https://en.wikipedia.org/wiki/MIME#Content-Disposition
+        _, filename = os.path.split(pdf_filename)
+        part.add_header('Content-Disposition', 'attachment', filename=filename)
+        self.attach(part)
+        logging.debug('Message PDF attachment: %s', pdf_filename)

--- a/cyhy/mailer/ReportMessage.py
+++ b/cyhy/mailer/ReportMessage.py
@@ -1,0 +1,39 @@
+from cyhy.mailer.Message import Message
+
+
+class ReportMessage(Message):
+    """A class representing an email message with a report PDF attachment.
+    """
+
+    def __init__(self, to_addrs, subject, text_body, html_body, pdf_filename, from_addr=Message.DefaultFrom, cc_addrs=Message.DefaultCc):
+        """Construct an instance.
+
+        Parameters
+        ----------
+        to_addrs : array of str
+            An array of string objects, each of which is an email
+            address to which this message should be sent.
+
+        subject : str
+            The subject of this email message.
+
+        text_body : str
+            The plain-text version of the email body.
+
+        html_body : str
+            The HTML version of the email body.
+
+        pdf_filename : str
+            The filename of the PDF file that is the report to be
+            attached to this message.
+
+        from_addr : str
+            The email address from which this message is to be sent.
+
+        cc_addrs : array of str
+            An array of string objects, each of which is a CC email
+            address to which this message should be sent.
+        """
+        Message.__init__(self, to_addrs, subject, text_body, html_body, from_addr, cc_addrs)
+
+        self.attach_pdf(pdf_filename)

--- a/cyhy/mailer/TmailMessage.py
+++ b/cyhy/mailer/TmailMessage.py
@@ -1,0 +1,131 @@
+import pystache
+
+from cyhy.mailer.Message import Message
+from cyhy.mailer.ReportMessage import ReportMessage
+
+
+class TmailMessage(ReportMessage):
+    """A class representing an email message with a Trustworthy Email
+    report PDF attachment.
+
+    Static attributes
+    -----------------
+    Subject : str
+        The mustache template to use when constructing the message
+        subject.
+
+    TextBody : str
+        The mustache template to use when constructing the plain text
+        message body.
+
+    HtmlBody : str
+        The mustache template to use when constructing the HTML
+        message body.
+    """
+
+    Subject = '{{acronym}} - Trustworthy Email Report - {{report_date}} Results'
+
+    TextBody = '''Greetings {{acronym}},
+
+Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on {{report_date}}.
+
+DHS Binding Operational Directive 18-01 requires your agency to take certain actions relevant to the data in this report:
+* Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* Within one year of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.
+
+Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's scope includes any domain suffix.
+
+The actions the Directive requires increase the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See https://cyber.dhs.gov/#intro for more information about email authentication, and https://cyber.dhs.gov/#guide for a compliance checklist and FAQ.
+
+If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to file an issue on our open-source scanner at https://github.com/dhs-ncats/trustymail.
+
+We welcome your feedback and questions.
+
+Cheers,
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity & Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+12/11/2017
+* Known issue: The fed.us TLD is inaccurately represented in some reports.
+-----------------
+'''
+
+    HtmlBody = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings {{acronym}},</p>
+<p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on {{report_date}}.</b></p>
+<p><a href="https://cyber.dhs.gov">DHS Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
+<ul>
+<li>Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of &ldquo;p=none&rdquo; and at least one address defined as a recipient of aggregate and/or failure reports.</li>
+<li>Within one year of BOD issuance, set a DMARC policy of &ldquo;reject&rdquo; for all second-level domains and mail-sending hosts.</li>
+<li>(The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.</li>
+</ul>
+</p>
+<p>Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's <a href="https://cyber.dhs.gov/guide/#what-is-the-scope-of-bod-18-01">scope includes any domain suffix</a>.</p>
+<p>The actions the Directive requires increases the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See <a href="https://cyber.dhs.gov/#intro">cyber.dhs.gov/#intro</a> for more information about email authentication, and <a href="https://cyber.dhs.gov/#guide">cyber.dhs.gov/#guide</a> for a compliance checklist and FAQ.</p>
+<p>If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to <a href="https://github.com/dhs-ncats/trustymail">file an issue</a> on our open-source scanner.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity & Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a> </p>
+</div></p><br>
+<p>----changelog----</p>
+<p><i>12/11/2017</i></p>
+<b>* Known issue:</b> The fed.us TLD is inaccurately represented in some reports.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+
+    def __init__(self, to_addrs, pdf_filename, agency_acronym, report_date, from_addr=Message.DefaultFrom, cc_addrs=Message.DefaultCc):
+        """Construct an instance.
+
+        Parameters
+        ----------
+        to_addrs : array of str
+            An array of string objects, each of which is an email
+            address to which this message should be sent.
+
+        pdf_filename : str
+            The filename of the PDF file that is the Trustworthy Email
+            report corresponding to this message.
+
+        agency_acronym : str
+            The acronym used by the agency corresponding to the
+            Trustworthy Email report attachment.
+
+        report_date : str
+            The date corresponding to the Trustworthy Email report
+            attachment.  We have been using dates of the form December
+            12, 2017.
+
+        from_addr : str
+            The email address from which this message is to be sent.
+
+        cc_addrs : array of str
+            An array of string objects, each of which is a CC email
+            address to which this message should be sent.
+        """
+        # This is the data mustache will use to render the templates
+        mustache_data = {
+            'acronym': agency_acronym,
+            'report_date': report_date
+        }
+
+        # Render the templates
+        subject = pystache.render(TmailMessage.Subject, mustache_data)
+        text_body = pystache.render(TmailMessage.TextBody, mustache_data)
+        html_body = pystache.render(TmailMessage.HtmlBody, mustache_data)
+
+        ReportMessage.__init__(self, to_addrs, subject, text_body, html_body, pdf_filename, from_addr, cc_addrs)

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.0.1-dev'
+__version__ = '1.0.0-dev'

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -4,7 +4,7 @@
 
 Usage:
   cyhy-mailer [options]
-  cyhy-mailer [--cyhy-report-dir=DIRECTORY] [--tmail-report-dir=DIRECTORY] [--https-report-dir=DIRECTORY] [--financial-year=YEAR] [--fy-quarter=QUARTER] [--mail-server=SERVER] [--mail-port=PORT] [--db-creds-file=FILENAME] [--debug]
+  cyhy-mailer [--cyhy-report-dir=DIRECTORY] [--tmail-report-dir=DIRECTORY] [--https-report-dir=DIRECTORY] [--mail-server=SERVER] [--mail-port=PORT] [--db-creds-file=FILENAME] [--debug]
   cyhy-mailer (-h | --help)
 
 Options:
@@ -226,6 +226,10 @@ def main():
 
         ###
         # Find and mail the trustymail report, if necessary
+        #
+        # This is very similar to the previous block but slightly
+        # different.  I need to figure out how to isolate the common
+        # functionality into a class or functions.
         ###
         tmail_report_dir = args['--tmail-report-dir']
         if tmail_report_dir:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup module for cyhy-mailer
 
 Based on:
 
-- https://github.com/jsf9k/cyhy-mailer
+- https://github.com/dhs-ncats/cyhy-mailer
 """
 
 from setuptools import setup
@@ -17,7 +17,7 @@ setup(
     # NCATS "homepage"
     url='https://www.dhs.gov/cyber-incident-response',
     # The project's main homepage
-    download_url='https://github.com/jsf9k/cyhy-mailer',
+    download_url='https://github.com/dhs-ncats/cyhy-mailer',
 
     # Author details
     author='Department of Homeland Security, National Cybersecurity Assessments and Technical Services team',

--- a/tests/test_cyhymessage.py
+++ b/tests/test_cyhymessage.py
@@ -5,24 +5,23 @@ from cyhy.mailer.CyhyMessage import CyhyMessage
 
 class Test(unittest.TestCase):
 
-    def test_five_params_single_recipient(self):
+    def test_four_params_single_recipient(self):
         to = ['recipient@example.com']
         pdf = './tests/data/pdf-sample.pdf'
         agency_acronym = 'CLARKE'
-        financial_year = '2001'
-        fy_quarter = '3'
+        report_date = 'December 15, 2001'
 
-        message = CyhyMessage(to, pdf, agency_acronym, financial_year, fy_quarter)
+        message = CyhyMessage(to, pdf, agency_acronym, report_date)
 
         self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
-        self.assertEqual(message['Subject'], 'CLARKE - CyHy - FY2001 Q3 Results')
+        self.assertEqual(message['Subject'], 'CLARKE - Cyber Hygiene Report - December 15, 2001 Results')
         self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
         self.assertEqual(message['To'], 'recipient@example.com')
 
         # Grab the bytes that comprise the attachment
         bytes = open(pdf, 'rb').read()
 
-        # Make sure the correct attachment was added
+        # Make sure the correct body and PDF attachments were added
         for part in message.walk():
             # multipart/* are just containers
             if part.get_content_type() == 'application/pdf':
@@ -70,24 +69,23 @@ U.S. Department of Homeland Security<br>
 '''
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_five_params_multiple_recipients(self):
+    def test_four_params_multiple_recipients(self):
         to = ['recipient@example.com', 'recipient2@example.com']
         pdf = './tests/data/pdf-sample.pdf'
         agency_acronym = 'CLARKE'
-        financial_year = '2001'
-        fy_quarter = '3'
+        report_date = 'December 15, 2001'
 
-        message = CyhyMessage(to, pdf, agency_acronym, financial_year, fy_quarter)
+        message = CyhyMessage(to, pdf, agency_acronym, report_date)
 
         self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
-        self.assertEqual(message['Subject'], 'CLARKE - CyHy - FY2001 Q3 Results')
+        self.assertEqual(message['Subject'], 'CLARKE - Cyber Hygiene Report - December 15, 2001 Results')
         self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
         self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
 
         # Grab the bytes that comprise the attachment
         bytes = open(pdf, 'rb').read()
 
-        # Make sure the correct attachment was added
+        # Make sure the correct body and PDF attachments were added
         for part in message.walk():
             # multipart/* are just containers
             if part.get_content_type() == 'application/pdf':
@@ -135,26 +133,25 @@ U.S. Department of Homeland Security<br>
 '''
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_seven_params_single_cc(self):
+    def test_six_params_single_cc(self):
         to = ['recipient@example.com', 'recipient2@example.com']
         pdf = './tests/data/pdf-sample.pdf'
         fm = 'sender@example.com'
         cc = ['cc@example.com']
         agency_acronym = 'CLARKE'
-        financial_year = '2001'
-        fy_quarter = '3'
+        report_date = 'December 15, 2001'
 
-        message = CyhyMessage(to, pdf, agency_acronym, financial_year, fy_quarter, from_addr=fm, cc_addrs=cc)
+        message = CyhyMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
 
         self.assertEqual(message['From'], fm)
-        self.assertEqual(message['Subject'], 'CLARKE - CyHy - FY2001 Q3 Results')
+        self.assertEqual(message['Subject'], 'CLARKE - Cyber Hygiene Report - December 15, 2001 Results')
         self.assertEqual(message['CC'], 'cc@example.com')
         self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
 
         # Grab the bytes that comprise the attachment
         bytes = open(pdf, 'rb').read()
 
-        # Make sure the correct attachment was added
+        # Make sure the correct body and PDF attachments were added
         for part in message.walk():
             # multipart/* are just containers
             if part.get_content_type() == 'application/pdf':
@@ -202,26 +199,25 @@ U.S. Department of Homeland Security<br>
 '''
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_seven_params_multiple_cc(self):
+    def test_six_params_multiple_cc(self):
         to = ['recipient@example.com', 'recipient2@example.com']
         pdf = './tests/data/pdf-sample.pdf'
         fm = 'sender@example.com'
         cc = ['cc@example.com', 'cc2@example.com']
         agency_acronym = 'CLARKE'
-        financial_year = '2001'
-        fy_quarter = '3'
+        report_date = 'December 15, 2001'
 
-        message = CyhyMessage(to, pdf, agency_acronym, financial_year, fy_quarter, from_addr=fm, cc_addrs=cc)
+        message = CyhyMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
 
         self.assertEqual(message['From'], fm)
-        self.assertEqual(message['Subject'], 'CLARKE - CyHy - FY2001 Q3 Results')
+        self.assertEqual(message['Subject'], 'CLARKE - Cyber Hygiene Report - December 15, 2001 Results')
         self.assertEqual(message['CC'], 'cc@example.com,cc2@example.com')
         self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
 
         # Grab the bytes that comprise the attachment
         bytes = open(pdf, 'rb').read()
 
-        # Make sure the correct attachment was added
+        # Make sure the correct body and PDF attachments were added
         for part in message.walk():
             # multipart/* are just containers
             if part.get_content_type() == 'application/pdf':

--- a/tests/test_httpsmessage.py
+++ b/tests/test_httpsmessage.py
@@ -1,0 +1,390 @@
+import unittest
+
+from cyhy.mailer.HttpsMessage import HttpsMessage
+
+
+class Test(unittest.TestCase):
+
+    def test_four_params_single_recipient(self):
+        to = ['recipient@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = HttpsMessage(to, pdf, agency_acronym, report_date)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['Subject'], 'CLARKE - HTTPS Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                text_body = '''Greetings CLARKE,
+
+Attached is your latest HTTPS Report.
+
+This report is intended to assist your agency in complying with OMB M-15-13 and DHS Binding Operational Directive 18-01. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)
+
+This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's Digital Analytics Program, Censys.io, and data from the End of Term Web Archive. The data in this report comes from a scan that took place on December 15, 2001.
+
+The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. For domains where "Live" == "True", when "Domain Supports HTTPS", "Domain Enforces HTTPS", and "Domain Uses Strong HSTS" are all "True", OR where "HSTS Base Domain Preloaded" is "True", that domain is M-15-13 compliant. Domains where "Live" == "False" are not web-responsive and do not fall under M-15-13's scope.
+
+We welcome your feedback and questions.
+
+Cheers,<br>
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity and Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+03/28/2017
+* Fixed: Compliance scores in the "Executive Summary" now account for preloaded domains. Preloading is OMB's preferred method for HSTS compliance.
+
+02/15/2017
+* Fixed an issue where some hostnames would appear twice in pshtt-results.csv
+* Fixed: A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly
+* Known issue: Compliance scores in the "Executive Summary" section are not yet accounting for preloaded domains
+
+01/25/2017
+* Fixed: A flaw in the report logic would sometimes cause the "Results" section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were "HSTS Preload Ready" or "HSTS Preload Pending" as preloaded (a checkmark).
+* Added: The report will now represent domains with "bad chain" errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 not requiring the use of a particular certificate authority
+--------------------
+'''
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your latest HTTPS Report.</p>
+<p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and DHS <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)</p>
+<p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p>The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. <i>For domains where &ldquo;Live&rdquo; == &ldquo;True&rdquo;</i>, when &ldquo;Domain Supports HTTPS&rdquo;, &ldquo;Domain Enforces HTTPS&rdquo;, and &ldquo;Domain Uses Strong HSTS&rdquo; are all &ldquo;True&rdquo;, OR where &ldquo;HSTS Base Domain Preloaded&rdquo; is &ldquo;True&rdquo;, that domain is M-15-13 compliant. Domains where &ldquo;Live&rdquo; == &ldquo;False&rdquo; are not web-responsive and do not fall under M-15-13's scope.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity and Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a>
+</p>
+</div>
+</p><br>
+<p>----changelog----</p>
+<p><i>03/28/2017</i></p>
+<p><b>* Fixed:</b> Compliance scores in the &ldquo;Executive Summary&rdquo; now account for preloaded domains. Preloading is OMB's <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">preferred method</a> for HSTS compliance.</p></p>
+<p><i>02/15/2017</i></p>
+<p><b>* Fixed</b> an issue where some hostnames would appear twice in<b> pshtt-results.csv <br>
+* Fixed: </b>A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly<br>
+<b>* Known issue</b>: Compliance scores in the &ldquo;Executive Summary&rdquo; section are not yet accounting for preloaded domains</p>
+<p><i>01/25/2017</i></p>
+<p><b>* Fixed</b>: A flaw in the report logic would sometimes cause the &ldquo;Results&rdquo; section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were &ldquo;HSTS Preload Ready&rdquo; or &ldquo;HSTS Preload Pending&rdquo; as preloaded (a checkmark).<br>
+<b>* Added</b>: The report will now represent domains with &ldquo;bad chain&rdquo; errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 <a href="https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f">not requiring the use of a particular certificate authority</a>.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_four_params_multiple_recipients(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = HttpsMessage(to, pdf, agency_acronym, report_date)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['Subject'], 'CLARKE - HTTPS Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your latest HTTPS Report.
+
+This report is intended to assist your agency in complying with OMB M-15-13 and DHS Binding Operational Directive 18-01. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)
+
+This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's Digital Analytics Program, Censys.io, and data from the End of Term Web Archive. The data in this report comes from a scan that took place on December 15, 2001.
+
+The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. For domains where "Live" == "True", when "Domain Supports HTTPS", "Domain Enforces HTTPS", and "Domain Uses Strong HSTS" are all "True", OR where "HSTS Base Domain Preloaded" is "True", that domain is M-15-13 compliant. Domains where "Live" == "False" are not web-responsive and do not fall under M-15-13's scope.
+
+We welcome your feedback and questions.
+
+Cheers,<br>
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity and Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+03/28/2017
+* Fixed: Compliance scores in the "Executive Summary" now account for preloaded domains. Preloading is OMB's preferred method for HSTS compliance.
+
+02/15/2017
+* Fixed an issue where some hostnames would appear twice in pshtt-results.csv
+* Fixed: A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly
+* Known issue: Compliance scores in the "Executive Summary" section are not yet accounting for preloaded domains
+
+01/25/2017
+* Fixed: A flaw in the report logic would sometimes cause the "Results" section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were "HSTS Preload Ready" or "HSTS Preload Pending" as preloaded (a checkmark).
+* Added: The report will now represent domains with "bad chain" errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 not requiring the use of a particular certificate authority
+--------------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your latest HTTPS Report.</p>
+<p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and DHS <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)</p>
+<p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p>The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. <i>For domains where &ldquo;Live&rdquo; == &ldquo;True&rdquo;</i>, when &ldquo;Domain Supports HTTPS&rdquo;, &ldquo;Domain Enforces HTTPS&rdquo;, and &ldquo;Domain Uses Strong HSTS&rdquo; are all &ldquo;True&rdquo;, OR where &ldquo;HSTS Base Domain Preloaded&rdquo; is &ldquo;True&rdquo;, that domain is M-15-13 compliant. Domains where &ldquo;Live&rdquo; == &ldquo;False&rdquo; are not web-responsive and do not fall under M-15-13's scope.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity and Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a>
+</p>
+</div>
+</p><br>
+<p>----changelog----</p>
+<p><i>03/28/2017</i></p>
+<p><b>* Fixed:</b> Compliance scores in the &ldquo;Executive Summary&rdquo; now account for preloaded domains. Preloading is OMB's <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">preferred method</a> for HSTS compliance.</p></p>
+<p><i>02/15/2017</i></p>
+<p><b>* Fixed</b> an issue where some hostnames would appear twice in<b> pshtt-results.csv <br>
+* Fixed: </b>A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly<br>
+<b>* Known issue</b>: Compliance scores in the &ldquo;Executive Summary&rdquo; section are not yet accounting for preloaded domains</p>
+<p><i>01/25/2017</i></p>
+<p><b>* Fixed</b>: A flaw in the report logic would sometimes cause the &ldquo;Results&rdquo; section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were &ldquo;HSTS Preload Ready&rdquo; or &ldquo;HSTS Preload Pending&rdquo; as preloaded (a checkmark).<br>
+<b>* Added</b>: The report will now represent domains with &ldquo;bad chain&rdquo; errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 <a href="https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f">not requiring the use of a particular certificate authority</a>.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_single_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        fm = 'sender@example.com'
+        cc = ['cc@example.com']
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = HttpsMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], 'CLARKE - HTTPS Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'cc@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your latest HTTPS Report.
+
+This report is intended to assist your agency in complying with OMB M-15-13 and DHS Binding Operational Directive 18-01. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)
+
+This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's Digital Analytics Program, Censys.io, and data from the End of Term Web Archive. The data in this report comes from a scan that took place on December 15, 2001.
+
+The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. For domains where "Live" == "True", when "Domain Supports HTTPS", "Domain Enforces HTTPS", and "Domain Uses Strong HSTS" are all "True", OR where "HSTS Base Domain Preloaded" is "True", that domain is M-15-13 compliant. Domains where "Live" == "False" are not web-responsive and do not fall under M-15-13's scope.
+
+We welcome your feedback and questions.
+
+Cheers,<br>
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity and Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+03/28/2017
+* Fixed: Compliance scores in the "Executive Summary" now account for preloaded domains. Preloading is OMB's preferred method for HSTS compliance.
+
+02/15/2017
+* Fixed an issue where some hostnames would appear twice in pshtt-results.csv
+* Fixed: A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly
+* Known issue: Compliance scores in the "Executive Summary" section are not yet accounting for preloaded domains
+
+01/25/2017
+* Fixed: A flaw in the report logic would sometimes cause the "Results" section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were "HSTS Preload Ready" or "HSTS Preload Pending" as preloaded (a checkmark).
+* Added: The report will now represent domains with "bad chain" errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 not requiring the use of a particular certificate authority
+--------------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your latest HTTPS Report.</p>
+<p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and DHS <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)</p>
+<p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p>The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. <i>For domains where &ldquo;Live&rdquo; == &ldquo;True&rdquo;</i>, when &ldquo;Domain Supports HTTPS&rdquo;, &ldquo;Domain Enforces HTTPS&rdquo;, and &ldquo;Domain Uses Strong HSTS&rdquo; are all &ldquo;True&rdquo;, OR where &ldquo;HSTS Base Domain Preloaded&rdquo; is &ldquo;True&rdquo;, that domain is M-15-13 compliant. Domains where &ldquo;Live&rdquo; == &ldquo;False&rdquo; are not web-responsive and do not fall under M-15-13's scope.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity and Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a>
+</p>
+</div>
+</p><br>
+<p>----changelog----</p>
+<p><i>03/28/2017</i></p>
+<p><b>* Fixed:</b> Compliance scores in the &ldquo;Executive Summary&rdquo; now account for preloaded domains. Preloading is OMB's <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">preferred method</a> for HSTS compliance.</p></p>
+<p><i>02/15/2017</i></p>
+<p><b>* Fixed</b> an issue where some hostnames would appear twice in<b> pshtt-results.csv <br>
+* Fixed: </b>A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly<br>
+<b>* Known issue</b>: Compliance scores in the &ldquo;Executive Summary&rdquo; section are not yet accounting for preloaded domains</p>
+<p><i>01/25/2017</i></p>
+<p><b>* Fixed</b>: A flaw in the report logic would sometimes cause the &ldquo;Results&rdquo; section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were &ldquo;HSTS Preload Ready&rdquo; or &ldquo;HSTS Preload Pending&rdquo; as preloaded (a checkmark).<br>
+<b>* Added</b>: The report will now represent domains with &ldquo;bad chain&rdquo; errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 <a href="https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f">not requiring the use of a particular certificate authority</a>.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_multiple_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        fm = 'sender@example.com'
+        cc = ['cc@example.com', 'cc2@example.com']
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = HttpsMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], 'CLARKE - HTTPS Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'cc@example.com,cc2@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your latest HTTPS Report.
+
+This report is intended to assist your agency in complying with OMB M-15-13 and DHS Binding Operational Directive 18-01. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)
+
+This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's Digital Analytics Program, Censys.io, and data from the End of Term Web Archive. The data in this report comes from a scan that took place on December 15, 2001.
+
+The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. For domains where "Live" == "True", when "Domain Supports HTTPS", "Domain Enforces HTTPS", and "Domain Uses Strong HSTS" are all "True", OR where "HSTS Base Domain Preloaded" is "True", that domain is M-15-13 compliant. Domains where "Live" == "False" are not web-responsive and do not fall under M-15-13's scope.
+
+We welcome your feedback and questions.
+
+Cheers,<br>
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity and Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+03/28/2017
+* Fixed: Compliance scores in the "Executive Summary" now account for preloaded domains. Preloading is OMB's preferred method for HSTS compliance.
+
+02/15/2017
+* Fixed an issue where some hostnames would appear twice in pshtt-results.csv
+* Fixed: A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly
+* Known issue: Compliance scores in the "Executive Summary" section are not yet accounting for preloaded domains
+
+01/25/2017
+* Fixed: A flaw in the report logic would sometimes cause the "Results" section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were "HSTS Preload Ready" or "HSTS Preload Pending" as preloaded (a checkmark).
+* Added: The report will now represent domains with "bad chain" errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 not requiring the use of a particular certificate authority
+--------------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your latest HTTPS Report.</p>
+<p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and DHS <a href="https://cyber.dhs.gov">Binding Operational Directive 18-01</a>. (In December, the body of this report will be updated to reflect the web-centric requirements of the BOD beyond just HTTPS/HSTS.)</p>
+<p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p>The embedded CSV, pshtt-results.csv, contains the raw scores for compliance. <i>For domains where &ldquo;Live&rdquo; == &ldquo;True&rdquo;</i>, when &ldquo;Domain Supports HTTPS&rdquo;, &ldquo;Domain Enforces HTTPS&rdquo;, and &ldquo;Domain Uses Strong HSTS&rdquo; are all &ldquo;True&rdquo;, OR where &ldquo;HSTS Base Domain Preloaded&rdquo; is &ldquo;True&rdquo;, that domain is M-15-13 compliant. Domains where &ldquo;Live&rdquo; == &ldquo;False&rdquo; are not web-responsive and do not fall under M-15-13's scope.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity and Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a>
+</p>
+</div>
+</p><br>
+<p>----changelog----</p>
+<p><i>03/28/2017</i></p>
+<p><b>* Fixed:</b> Compliance scores in the &ldquo;Executive Summary&rdquo; now account for preloaded domains. Preloading is OMB's <a href="https://https.cio.gov/guide/#options-for-hsts-compliance">preferred method</a> for HSTS compliance.</p></p>
+<p><i>02/15/2017</i></p>
+<p><b>* Fixed</b> an issue where some hostnames would appear twice in<b> pshtt-results.csv <br>
+* Fixed: </b>A local caching error caused domains that have been HSTS preloaded after December 19th, 2016 to be reported incorrectly<br>
+<b>* Known issue</b>: Compliance scores in the &ldquo;Executive Summary&rdquo; section are not yet accounting for preloaded domains</p>
+<p><i>01/25/2017</i></p>
+<p><b>* Fixed</b>: A flaw in the report logic would sometimes cause the &ldquo;Results&rdquo; section of the PDF to inaccurately represent raw pshtt scores. This error would also represent domains that were &ldquo;HSTS Preload Ready&rdquo; or &ldquo;HSTS Preload Pending&rdquo; as preloaded (a checkmark).<br>
+<b>* Added</b>: The report will now represent domains with &ldquo;bad chain&rdquo; errors (but not hostname or expired certificate errors) that otherwise satisfy M-15-13 as compliant. This is in line with M-15-13 <a href="https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f">not requiring the use of a particular certificate authority</a>.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,74 @@
+import unittest
+
+from cyhy.mailer.Message import Message
+
+
+class Test(unittest.TestCase):
+
+    def test_one_param_single_recipient(self):
+        to = ['recipient@example.com']
+
+        message = Message(to)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com')
+
+    def test_one_param_multiple_recipients(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+
+        message = Message(to)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+    def test_six_params_single_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        fm = 'sender@example.com'
+        cc = ['cc@example.com']
+        subject = 'The subject'
+        text_body = 'The plain-text body'
+        html_body = '<p>The HTML body</p>'
+
+        message = Message(to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], subject)
+        self.assertEqual(message['CC'], 'cc@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Make sure the correct body attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'text/plain':
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_multiple_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        fm = 'sender@example.com'
+        cc = ['cc@example.com', 'cc2@example.com']
+        subject = 'The subject'
+        text_body = 'The plain-text body'
+        html_body = '<p>The HTML body</p>'
+
+        message = Message(to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], subject)
+        self.assertEqual(message['CC'], 'cc@example.com,cc2@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Make sure the correct body attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'text/plain':
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                self.assertEqual(part.get_payload(), html_body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reportmessage.py
+++ b/tests/test_reportmessage.py
@@ -1,0 +1,68 @@
+import unittest
+
+from cyhy.mailer.ReportMessage import ReportMessage
+
+
+class Test(unittest.TestCase):
+
+    def test_five_params(self):
+        to = ['recipient@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        subject = 'The subject'
+        text_body = 'The plain-text body'
+        html_body = '<p>The HTML body</p>'
+
+        message = ReportMessage(to, subject, text_body, html_body, pdf)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['Subject'], subject)
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_seven_params(self):
+        to = ['recipient@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        subject = 'The subject'
+        text_body = 'The plain-text body'
+        html_body = '<p>The HTML body</p>'
+        fm = 'sender@example.com'
+        cc = ['cc@example.com']
+
+        message = ReportMessage(to, subject, text_body, html_body, pdf, fm, cc)
+
+        self.assertEqual(message['From'], 'sender@example.com')
+        self.assertEqual(message['Subject'], subject)
+        self.assertEqual(message['CC'], 'cc@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                self.assertEqual(part.get_payload(), html_body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tmailmessage.py
+++ b/tests/test_tmailmessage.py
@@ -1,0 +1,366 @@
+import unittest
+
+from cyhy.mailer.TmailMessage import TmailMessage
+
+
+class Test(unittest.TestCase):
+
+    def test_four_params_single_recipient(self):
+        to = ['recipient@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = TmailMessage(to, pdf, agency_acronym, report_date)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['Subject'], 'CLARKE - Trustworthy Email Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                text_body = '''Greetings CLARKE,
+
+Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
+
+DHS Binding Operational Directive 18-01 requires your agency to take certain actions relevant to the data in this report:
+* Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* Within one year of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.
+
+Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's scope includes any domain suffix.
+
+The actions the Directive requires increase the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See https://cyber.dhs.gov/#intro for more information about email authentication, and https://cyber.dhs.gov/#guide for a compliance checklist and FAQ.
+
+If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to file an issue on our open-source scanner at https://github.com/dhs-ncats/trustymail.
+
+We welcome your feedback and questions.
+
+Cheers,
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity & Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+12/11/2017
+* Known issue: The fed.us TLD is inaccurately represented in some reports.
+-----------------
+'''
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p><a href="https://cyber.dhs.gov">DHS Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
+<ul>
+<li>Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of &ldquo;p=none&rdquo; and at least one address defined as a recipient of aggregate and/or failure reports.</li>
+<li>Within one year of BOD issuance, set a DMARC policy of &ldquo;reject&rdquo; for all second-level domains and mail-sending hosts.</li>
+<li>(The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.</li>
+</ul>
+</p>
+<p>Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's <a href="https://cyber.dhs.gov/guide/#what-is-the-scope-of-bod-18-01">scope includes any domain suffix</a>.</p>
+<p>The actions the Directive requires increases the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See <a href="https://cyber.dhs.gov/#intro">cyber.dhs.gov/#intro</a> for more information about email authentication, and <a href="https://cyber.dhs.gov/#guide">cyber.dhs.gov/#guide</a> for a compliance checklist and FAQ.</p>
+<p>If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to <a href="https://github.com/dhs-ncats/trustymail">file an issue</a> on our open-source scanner.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity & Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a> </p>
+</div></p><br>
+<p>----changelog----</p>
+<p><i>12/11/2017</i></p>
+<b>* Known issue:</b> The fed.us TLD is inaccurately represented in some reports.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_four_params_multiple_recipients(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = TmailMessage(to, pdf, agency_acronym, report_date)
+
+        self.assertEqual(message['From'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['Subject'], 'CLARKE - Trustworthy Email Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'ncats@hq.dhs.gov')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
+
+DHS Binding Operational Directive 18-01 requires your agency to take certain actions relevant to the data in this report:
+* Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* Within one year of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.
+
+Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's scope includes any domain suffix.
+
+The actions the Directive requires increase the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See https://cyber.dhs.gov/#intro for more information about email authentication, and https://cyber.dhs.gov/#guide for a compliance checklist and FAQ.
+
+If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to file an issue on our open-source scanner at https://github.com/dhs-ncats/trustymail.
+
+We welcome your feedback and questions.
+
+Cheers,
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity & Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+12/11/2017
+* Known issue: The fed.us TLD is inaccurately represented in some reports.
+-----------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p><a href="https://cyber.dhs.gov">DHS Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
+<ul>
+<li>Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of &ldquo;p=none&rdquo; and at least one address defined as a recipient of aggregate and/or failure reports.</li>
+<li>Within one year of BOD issuance, set a DMARC policy of &ldquo;reject&rdquo; for all second-level domains and mail-sending hosts.</li>
+<li>(The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.</li>
+</ul>
+</p>
+<p>Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's <a href="https://cyber.dhs.gov/guide/#what-is-the-scope-of-bod-18-01">scope includes any domain suffix</a>.</p>
+<p>The actions the Directive requires increases the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See <a href="https://cyber.dhs.gov/#intro">cyber.dhs.gov/#intro</a> for more information about email authentication, and <a href="https://cyber.dhs.gov/#guide">cyber.dhs.gov/#guide</a> for a compliance checklist and FAQ.</p>
+<p>If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to <a href="https://github.com/dhs-ncats/trustymail">file an issue</a> on our open-source scanner.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity & Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a> </p>
+</div></p><br>
+<p>----changelog----</p>
+<p><i>12/11/2017</i></p>
+<b>* Known issue:</b> The fed.us TLD is inaccurately represented in some reports.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_single_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        fm = 'sender@example.com'
+        cc = ['cc@example.com']
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = TmailMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], 'CLARKE - Trustworthy Email Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'cc@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
+
+DHS Binding Operational Directive 18-01 requires your agency to take certain actions relevant to the data in this report:
+* Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* Within one year of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.
+
+Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's scope includes any domain suffix.
+
+The actions the Directive requires increase the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See https://cyber.dhs.gov/#intro for more information about email authentication, and https://cyber.dhs.gov/#guide for a compliance checklist and FAQ.
+
+If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to file an issue on our open-source scanner at https://github.com/dhs-ncats/trustymail.
+
+We welcome your feedback and questions.
+
+Cheers,
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity & Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+12/11/2017
+* Known issue: The fed.us TLD is inaccurately represented in some reports.
+-----------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p><a href="https://cyber.dhs.gov">DHS Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
+<ul>
+<li>Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of &ldquo;p=none&rdquo; and at least one address defined as a recipient of aggregate and/or failure reports.</li>
+<li>Within one year of BOD issuance, set a DMARC policy of &ldquo;reject&rdquo; for all second-level domains and mail-sending hosts.</li>
+<li>(The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.</li>
+</ul>
+</p>
+<p>Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's <a href="https://cyber.dhs.gov/guide/#what-is-the-scope-of-bod-18-01">scope includes any domain suffix</a>.</p>
+<p>The actions the Directive requires increases the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See <a href="https://cyber.dhs.gov/#intro">cyber.dhs.gov/#intro</a> for more information about email authentication, and <a href="https://cyber.dhs.gov/#guide">cyber.dhs.gov/#guide</a> for a compliance checklist and FAQ.</p>
+<p>If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to <a href="https://github.com/dhs-ncats/trustymail">file an issue</a> on our open-source scanner.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity & Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a> </p>
+</div></p><br>
+<p>----changelog----</p>
+<p><i>12/11/2017</i></p>
+<b>* Known issue:</b> The fed.us TLD is inaccurately represented in some reports.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_multiple_cc(self):
+        to = ['recipient@example.com', 'recipient2@example.com']
+        pdf = './tests/data/pdf-sample.pdf'
+        fm = 'sender@example.com'
+        cc = ['cc@example.com', 'cc2@example.com']
+        agency_acronym = 'CLARKE'
+        report_date = 'December 15, 2001'
+
+        message = TmailMessage(to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc)
+
+        self.assertEqual(message['From'], fm)
+        self.assertEqual(message['Subject'], 'CLARKE - Trustworthy Email Report - December 15, 2001 Results')
+        self.assertEqual(message['CC'], 'cc@example.com,cc2@example.com')
+        self.assertEqual(message['To'], 'recipient@example.com,recipient2@example.com')
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, 'rb').read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == 'application/pdf':
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), 'pdf-sample.pdf')
+            elif part.get_content_type() == 'text/plain':
+                body = '''Greetings CLARKE,
+
+Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
+
+DHS Binding Operational Directive 18-01 requires your agency to take certain actions relevant to the data in this report:
+* Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of "p=none" and at least one address defined as a recipient of aggregate and/or failure reports.
+* Within one year of BOD issuance, set a DMARC policy of "reject" for all second-level domains and mail-sending hosts.
+* The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.
+
+Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's scope includes any domain suffix.
+
+The actions the Directive requires increase the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See https://cyber.dhs.gov/#intro for more information about email authentication, and https://cyber.dhs.gov/#guide for a compliance checklist and FAQ.
+
+If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to file an issue on our open-source scanner at https://github.com/dhs-ncats/trustymail.
+
+We welcome your feedback and questions.
+
+Cheers,
+The NCATS Team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+National Cybersecurity & Communications Integration Center
+U.S. Department of Homeland Security
+ncats@hq.dhs.gov
+
+----changelog----
+12/11/2017
+* Known issue: The fed.us TLD is inaccurately represented in some reports.
+-----------------
+'''
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == 'text/html':
+                html_body = '''<html>
+<head></head>
+<body>
+<div style=""font-size:14.5"">
+<p>Greetings CLARKE,</p>
+<p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
+<p><a href="https://cyber.dhs.gov">DHS Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
+<ul>
+<li>Within 90 days of BOD issuance, configure all second-level domains to have valid SPF/DMARC records, with at minimum a DMARC policy of &ldquo;p=none&rdquo; and at least one address defined as a recipient of aggregate and/or failure reports.</li>
+<li>Within one year of BOD issuance, set a DMARC policy of &ldquo;reject&rdquo; for all second-level domains and mail-sending hosts.</li>
+<li>(The Directive additionally requires all internet-facing mail servers to offer STARTTLS. This data will be represented in the Trustworthy Email Report in December.</li>
+</ul>
+</p>
+<p>Raw results in this Report are available as a CSV in the Appendix, which includes error messages. Note that this report includes data from second-level .gov domains, but the Directive's <a href="https://cyber.dhs.gov/guide/#what-is-the-scope-of-bod-18-01">scope includes any domain suffix</a>.</p>
+<p>The actions the Directive requires increases the security of emails in transit and makes it easier to detect emails that attempt to spoof .gov domains. This protects intra-government users and the general public equally. See <a href="https://cyber.dhs.gov/#intro">cyber.dhs.gov/#intro</a> for more information about email authentication, and <a href="https://cyber.dhs.gov/#guide">cyber.dhs.gov/#guide</a> for a compliance checklist and FAQ.</p>
+<p>If you believe our reporting or methodology is in error, let us know. If the flaw appears tool-related, we encourage you to <a href="https://github.com/dhs-ncats/trustymail">file an issue</a> on our open-source scanner.</p>
+<p>We welcome your feedback and questions.</p>
+Cheers,<br>
+The NCATS Team<br><br />
+National Cybersecurity Assessments and Technical Services (NCATS)<br />
+National Cybersecurity & Communications Integration Center<br/>
+U.S. Department of Homeland Security <br/>
+<a href=""mailto:ncats@hq.dhs.gov""> ncats@hq.dhs.gov </a> </p>
+</div></p><br>
+<p>----changelog----</p>
+<p><i>12/11/2017</i></p>
+<b>* Known issue:</b> The fed.us TLD is inaccurately represented in some reports.</p>
+<p>--------------------</p>
+</body>
+</html>
+'''
+                self.assertEqual(part.get_payload(), html_body)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* What was CyhyMessage functionality now partially resides in a few base classes.  This makes it easier to create the `TmailMessage` and `HttpsMessage` classes.
* Changed GitHub URL from my personal account to dhs-ncats in `setup.py`
* Created `TmailMessage` for sending Trustworthy Email reports
* Now using the date of report creation in the email subject line instead of financial year/quarter
* Bumped version up to 1.0.0
* Changed the order that the text and HTML bodies are attached to the email messages.  The current order makes the HTML version the default version displayed, as long as the client supports it.
* Added a period to one of the list items in the unordered list for the `TmailMessage` text and HTML bodies.  This also necessitated some changes in the corresponding unit tests.

This resolves issue #7.